### PR TITLE
fix: favor prettier for object-curly-newline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spscommerce/typescript",
-  "version": "0.0.12",
+  "version": "0.0.15",
   "description": "SPS official style guides and lint configs for frontend development, forked from airbnb/javascript",
   "private": true,
   "scripts": {

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1590,8 +1590,6 @@ foo.init();
 
 <img src="../prettier.svg" height="18" align="center"/> **Enforced by Prettier**
 
-<img src="../eslint.svg" height="18" align="center"/> [`object-curly-newline`](https://eslint.org/docs/rules/object-curly-newline)
-
 > Why? The curly braces follow the same indentation rules as every other curly brace block in the style guide, as do the trailing commas.
 
 ```typescript
@@ -1608,6 +1606,8 @@ import {
   longNameE,
 } from 'path';
 ```
+
+Note: formerly we used [`object-curly-newline`](https://eslint.org/docs/rules/object-curly-newline) but have turned it off due to conflicts with how Prettier handles this.
 
 ---
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spscommerce/eslint-config-typescript",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "description": "SPS official linter configuration for TypeScript.",
   "main": "lib/index.js",
   "scripts": {

--- a/typescript/rules/stylisticIssues.ts
+++ b/typescript/rules/stylisticIssues.ts
@@ -427,14 +427,7 @@ export const stylisticIssues: Linter.RulesRecord = {
    * enforce line breaks between braces 🔧
    * https://eslint.org/docs/rules/object-curly-newline
    */
-  "object-curly-newline": [
-    "error",
-    {
-      minProperties: 4,
-      multiline: true,
-      consistent: true,
-    },
-  ],
+  "object-curly-newline": "off",
 
   /**
    * require padding inside curly braces 🔧


### PR DESCRIPTION
This turns of object-curly-newline because prettier handles it better and the two are often in conflict and one is left unable to commit their changes without a perpetual loop of tool changes.